### PR TITLE
Rework/api filters

### DIFF
--- a/api/everycache_api/common/filters.py
+++ b/api/everycache_api/common/filters.py
@@ -1,0 +1,73 @@
+import datetime
+
+from flask import request
+from marshmallow import fields
+
+
+def _parse_value(value, schema_field_type):
+    if schema_field_type == fields.Boolean:
+        value = value.lower() in ("1", "true")
+    elif schema_field_type == fields.Integer:
+        try:
+            value = int(value)
+        except ValueError:
+            return None
+    elif schema_field_type == fields.Float:
+        try:
+            value = float(value)
+        except ValueError:
+            return None
+    elif schema_field_type == fields.DateTime:
+        value = datetime.strptime(value, "%d-%m-%y")
+
+    return value
+
+
+def _filter_query(query, operation, model_field, value):
+    if operation is None:
+        query = query.filter(model_field == value)
+    elif operation == "lte":
+        query = query.filter(model_field <= value)
+    elif operation == "gte":
+        query = query.filter(model_field >= value)
+    elif operation == "lt":
+        query = query.filter(model_field < value)
+    elif operation == "gt":
+        query = query.filter(model_field > value)
+    elif operation == "not":
+        query = query.filter(model_field != value)
+    elif operation == "like":
+        query = query.filter(model_field.like(f"%{value}%"))
+    elif operation == "not-like":
+        query = query.filter(model_field.notlike(f"%{value}%"))
+
+    return query
+
+
+def _apply_filter(query, schema, field_name, filter_url_value):
+    split_result = filter_url_value.split(":")
+    try:
+        operation, value_string, *_ = split_result
+    except ValueError:
+        operation, value_string = None, next(iter(split_result))
+
+    schema_field_type = type(schema.fields[field_name])
+    value = _parse_value(value_string, schema_field_type)
+    if value is None:
+        return query
+
+    model_field = getattr(schema.Meta.model, field_name)
+    return _filter_query(query, operation, model_field, value)
+
+
+def apply_filters(query, schema):
+    args = request.args.to_dict(flat=False)
+
+    for key, values_list in args.items():
+        if key not in schema.fields:
+            continue
+
+        for value in values_list:
+            query = _apply_filter(query, schema, key, value)
+
+    return query

--- a/api/everycache_api/common/filters.py
+++ b/api/everycache_api/common/filters.py
@@ -60,7 +60,7 @@ def _apply_filter(query, schema, field_name, filter_url_value):
     return _filter_query(query, operation, model_field, value)
 
 
-def apply_filters(query, schema):
+def apply_query_filters(query, schema):
     args = request.args.to_dict(flat=False)
 
     for key, values_list in args.items():

--- a/api/everycache_api/common/ordering.py
+++ b/api/everycache_api/common/ordering.py
@@ -1,0 +1,38 @@
+from flask import request
+from sqlalchemy import asc, desc
+
+from everycache_api.extensions import ma
+
+
+def apply_ordering(query, schema):
+    ordering = desc if request.args.get("desc", "").lower() in ("1", "true") else asc
+    order_by = request.args.get("order_by")
+
+    if order_by:
+        schema_field = schema.fields.get(order_by)
+
+        if schema_field:
+            if type(schema_field) == ma.Nested:
+                # nested schema, unused for the time being
+                raise NotImplementedError()
+            if type(schema_field) == ma.Pluck:
+                # field nested from other schema
+
+                # join nested model to query
+                nested_schema_model = schema_field.schema.Meta.model
+                query = query.join(nested_schema_model)
+
+                # apply order_by nested model's db model field to query
+                nested_model_field = schema_field.field_name
+                query = query.order_by(
+                    ordering(getattr(nested_schema_model, nested_model_field))
+                )
+            else:
+                # own field
+                model = schema.Meta.model
+                model_field = schema_field.attribute or schema_field.name
+
+                # apply order_by
+                query = query.order_by(ordering(getattr(model, model_field)))
+
+    return query

--- a/api/everycache_api/common/ordering.py
+++ b/api/everycache_api/common/ordering.py
@@ -4,7 +4,7 @@ from sqlalchemy import asc, desc
 from everycache_api.extensions import ma
 
 
-def apply_ordering(query, schema):
+def apply_query_ordering(query, schema):
     ordering = desc if request.args.get("desc", "").lower() in ("1", "true") else asc
     order_by = request.args.get("order_by")
 

--- a/api/everycache_api/common/pagination.py
+++ b/api/everycache_api/common/pagination.py
@@ -1,8 +1,8 @@
 """Simple helper to paginate query"""
 from flask import request, url_for
-from sqlalchemy import asc, desc
 
-from everycache_api.extensions import ma
+from everycache_api.common.filters import apply_filters
+from everycache_api.common.ordering import apply_ordering
 
 DEFAULT_PAGE_SIZE = 50
 DEFAULT_PAGE_NUMBER = 1
@@ -14,57 +14,9 @@ def extract_pagination(page=None, per_page=None, **request_args):
     return page, per_page, request_args
 
 
-def apply_sorting_field(query, schema, order_by_field: str, descending: bool = False):
-    field = schema.fields.get(order_by_field)
-    ordering = desc if descending else asc
-
-    if not field:
-        # incorrect field
-        return query
-    elif type(field) == ma.Pluck:
-        # nested field
-        nested_schema_model = field.schema.Meta.model
-        nested_model_field = field.field_name
-        return query.join(nested_schema_model).order_by(
-            ordering(getattr(nested_schema_model, nested_model_field))
-        )
-    else:
-        # own field
-        schema_model = schema.Meta.model
-        model_field = field.attribute or field.name
-        return query.order_by(ordering(getattr(schema_model, model_field)))
-
-
 def paginate(query, schema):
-    order_by_field = request.args.get("order_by")
-    descending = request.args.get("desc", "").lower() in ("1", "true")
-
-    if order_by_field:
-        query = apply_sorting_field(query, schema, order_by_field, descending)
-
-    # if order_by:
-    #     field = schema.fields.get(order_by)
-    #     if field:
-    #         column = None
-    #         if field.attribute is None:
-    #             # schema field name equal to column name
-    #             column = order_by
-    #         elif "." not in field.attribute:
-    #             # schema field name different than column name, but from the same object
-    #             column = field.attribute
-    #         else:
-    #             # schema field name points to a different object in relationship
-    #             relationship, column = field.attribute.split(".")
-    #             db_model = getattr(schema.Meta.model, relationship).mapper.class_
-    #             column = getattr(db_model, column)
-    #             query = query.join(db_model)
-
-    #         if column:
-    #             # apply ordering to db query
-    #             if not descending:
-    #                 query = query.order_by(asc(column))
-    #             else:
-    #                 query = query.order_by(desc(column))
+    query = apply_ordering(query, schema)
+    query = apply_filters(query, schema)
 
     page, per_page, other_request_args = extract_pagination(**request.args)
     page_obj = query.paginate(page=page, per_page=per_page)

--- a/api/everycache_api/common/pagination.py
+++ b/api/everycache_api/common/pagination.py
@@ -1,8 +1,8 @@
 """Simple helper to paginate query"""
 from flask import request, url_for
 
-from everycache_api.common.filters import apply_filters
-from everycache_api.common.ordering import apply_ordering
+from everycache_api.common.filters import apply_query_filters
+from everycache_api.common.ordering import apply_query_ordering
 
 DEFAULT_PAGE_SIZE = 50
 DEFAULT_PAGE_NUMBER = 1
@@ -15,8 +15,8 @@ def extract_pagination(page=None, per_page=None, **request_args):
 
 
 def paginate(query, schema):
-    query = apply_ordering(query, schema)
-    query = apply_filters(query, schema)
+    query = apply_query_ordering(query, schema)
+    query = apply_query_filters(query, schema)
 
     page, per_page, other_request_args = extract_pagination(**request.args)
     page_obj = query.paginate(page=page, per_page=per_page)


### PR DESCRIPTION
I implemented the filtering solution.

The following operations are possible for filtering the list query:
(the part before ':' is the operation name, and 's' is a filter value)
- lte:s
- gte:s
- lt:s
- gt:s
- s
- not:s
- like:s
- not-like:s

Example request: `/api/users?email=not-like:niemi`

---
I also moved the ordering part of 'paginate' function to a separate file.