### PR TITLE
Fix each 'error' return statement in resources

### DIFF
--- a/api/everycache_api/api/resources/cache.py
+++ b/api/everycache_api/api/resources/cache.py
@@ -100,7 +100,7 @@ class CacheResource(Resource):
 
         # ensure current_user is authorized
         if current_user != cache.owner and current_user.role != User.Role.Admin:
-            return 403
+            return {}, 403
 
         schema = CacheSchema()
 
@@ -116,7 +116,7 @@ class CacheResource(Resource):
 
         # ensure current_user is authorized
         if current_user != cache.owner and current_user.role != User.Role.Admin:
-            return 403
+            return {}, 403
 
         # mark cache as deleted
         cache.deleted = True

--- a/api/everycache_api/api/resources/cache_comment.py
+++ b/api/everycache_api/api/resources/cache_comment.py
@@ -98,7 +98,7 @@ class CacheCommentResource(Resource):
 
         # ensure current_user is authorized
         if current_user != comment.author and current_user.role != User.Role.Admin:
-            return 403
+            return {}, 403
 
         schema = CacheCommentSchema()
 
@@ -119,7 +119,7 @@ class CacheCommentResource(Resource):
 
         # ensure current_user is authorized
         if current_user != comment.author and current_user.role != User.Role.Admin:
-            return 403
+            return {}, 403
 
         # mark comment as deleted
         comment.deleted = True

--- a/api/everycache_api/api/resources/cache_visit.py
+++ b/api/everycache_api/api/resources/cache_visit.py
@@ -98,7 +98,7 @@ class CacheVisitResource(Resource):
 
         # ensure current_user is authorized
         if current_user != visit.user and current_user.role != User.Role.Admin:
-            return 403
+            return {}, 403
 
         schema = CacheVisitSchema()
 
@@ -116,7 +116,7 @@ class CacheVisitResource(Resource):
 
         # ensure current_user is authorized
         if current_user != visit.user and current_user.role != User.Role.Admin:
-            return 403
+            return {}, 403
 
         # delete visit
         db.session.delete(visit)

--- a/api/everycache_api/api/resources/user.py
+++ b/api/everycache_api/api/resources/user.py
@@ -122,7 +122,7 @@ class UserResource(Resource):
     def put(self, username: str):
         # ensure current_user is authorized
         if current_user.username != username and current_user.role != User.Role.Admin:
-            return 403
+            return {}, 403
 
         # find user
         user = User.query.filter_by(username=username).first_or_404()
@@ -138,7 +138,7 @@ class UserResource(Resource):
     def delete(self, username: str):
         # ensure current_user is authorized
         if current_user.username != username and current_user.role != User.Role.Admin:
-            return 403
+            return {}, 403
 
         # find user
         user = User.query.filter(username=username).first_or_404()


### PR DESCRIPTION
These 'return 403' effectively put the 403 int inside of the response data instead of being interpreted as a status code.
Fixed it by returning an empty 'data' dict. There may be a prettier way to do it - if so, please let me know.